### PR TITLE
Unpublish plugin from the list

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "main": "dist/index.js",
   "keywords": [
     "cerebro",
-    "cerebro-plugin",
     "reload",
     "refresh",
     "vim-ftw"


### PR DESCRIPTION
Without "cerebro-plugin" keyword this plugin won't be visible in plugins list